### PR TITLE
build: pin an updated soroban-cli; update bindings

### DIFF
--- a/liquidity-pool/.cargo/config.toml
+++ b/liquidity-pool/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias] # command aliases
+install_soroban = "install --git https://github.com/AhaLabs/soroban-tools --rev b90af8bf9df5a68fd67e3c297e5744ffcd66c07c --root ./target soroban-cli --debug --features opt"

--- a/liquidity-pool/README.md
+++ b/liquidity-pool/README.md
@@ -13,7 +13,8 @@ Getting Started
 Install Dependencies
 --------------------
 
-1. `soroban-cli v0.9.4`. See https://soroban.stellar.org/docs/getting-started/setup#install-the-soroban-cli
+0. Rust with `wasm32-unknown-unknown` target; see [Setup instructions](https://soroban.stellar.org/docs/getting-started/setup#install-rust)
+1. The version of `soroban-cli` specified in [.cargo/config.toml](./.cargo/config.toml)—this will be **installed automatically** the first time you run the `./initialize.sh` script. It will be built to the local `target/bin` directory. You can add `~/target/bin` [to your PATH](https://unix.stackexchange.com/questions/26047/how-to-correctly-add-a-path-to-path) to automatically use this version if you're in this directory (or any other with a `target/bin/soroban`) every time you type just `soroban`.
 2. If you want to run the Soroban RPC locally: `docker` (you can run both Standalone and Futurenet backends with it)
 3. `Node.js v16`
 4. [Freighter Wallet](https://www.freighter.app/) ≥[v5.0.2](https://github.com/stellar/freighter/releases/tag/2.9.1). Or from the Firefox / Chrome extension store. Once installed, enable "Experimental Mode" in the settings (gear icon).
@@ -25,8 +26,6 @@ Run Backend
 You have three options: 1. Deploy on [Futurenet](https://soroban.stellar.org/docs/getting-started/deploy-to-futurenet) using a remote [RPC](https://soroban.stellar.org/docs/getting-started/run-rpc) endpoint, 2. Run your own Futerenet RPC node with Docker and deploy to it, 3. run in [localnet/standalone](https://soroban.stellar.org/docs/getting-started/deploy-to-a-local-network) mode.
 
 ### Option 1: Deploy on Futurenet
-
-0. Make sure you have soroban-cli installed, as explained above
 
 1. Deploy the contracts and initialize them
 

--- a/liquidity-pool/frontend/.gitignore
+++ b/liquidity-pool/frontend/.gitignore
@@ -9,6 +9,7 @@
 /coverage
 
 # production
+dist
 /build
 storybook-static/
 

--- a/liquidity-pool/frontend/package-lock.json
+++ b/liquidity-pool/frontend/package-lock.json
@@ -91,12 +91,11 @@
       }
     },
     "../.soroban/contracts/liquidity-pool": {
-      "name": "liquidity-poo",
       "version": "0.0.0",
       "dependencies": {
         "@stellar/freighter-api": "1.5.1",
         "buffer": "6.0.3",
-        "soroban-client": "0.9.2"
+        "soroban-client": "0.11.1"
       },
       "devDependencies": {
         "typescript": "5.1.6"
@@ -119,7 +118,7 @@
       "dependencies": {
         "@stellar/freighter-api": "1.5.1",
         "buffer": "6.0.3",
-        "soroban-client": "0.9.2"
+        "soroban-client": "0.11.1"
       },
       "devDependencies": {
         "typescript": "5.1.6"
@@ -776,7 +775,7 @@
       "dependencies": {
         "@stellar/freighter-api": "1.5.1",
         "buffer": "6.0.3",
-        "soroban-client": "0.9.2"
+        "soroban-client": "0.11.1"
       },
       "devDependencies": {
         "typescript": "5.1.6"
@@ -1433,7 +1432,7 @@
       "dependencies": {
         "@stellar/freighter-api": "1.5.1",
         "buffer": "6.0.3",
-        "soroban-client": "0.9.2"
+        "soroban-client": "0.11.1"
       },
       "devDependencies": {
         "typescript": "5.1.6"

--- a/liquidity-pool/frontend/src/app/core/pages/home/index.tsx
+++ b/liquidity-pool/frontend/src/app/core/pages/home/index.tsx
@@ -11,10 +11,13 @@ import { LiquidityActions, AccountData } from 'components/organisms'
 
 import { Utils } from 'shared/utils'
 import { TokenAIcon, TokenBIcon } from "components/icons"
-import * as tokenAContract from 'token-a-contract'
-import * as tokenBContract from 'token-b-contract'
-import * as shareTokenContract from 'share-token-contract'
-import * as liquidityPoolContract from 'liquidity-pool-contract'
+import {
+  Address,
+  tokenAContract,
+  tokenBContract,
+  shareTokenContract,
+  liquidityPoolContract,
+} from '../../../../contracts'
 
 import { IToken } from 'interfaces/soroban/token';
 import { IReserves } from 'interfaces/soroban/liquidityPool';
@@ -71,9 +74,9 @@ const Home = (): JSX.Element => {
     });
     if (account) {
       Promise.all([
-        tokenAContract.balance({ id: account }),
-        tokenBContract.balance({ id: account }),
-        shareTokenContract.balance({ id: account })
+        tokenAContract.balance({ id: new Address(account) }),
+        tokenBContract.balance({ id: new Address(account) }),
+        shareTokenContract.balance({ id: new Address(account) })
       ]).then(fetched => {
         setTokenA(prevTokenA => ({
           ...prevTokenA,
@@ -104,7 +107,7 @@ const Home = (): JSX.Element => {
           tokenA={tokenA}
           tokenB={tokenB}
           shareToken={shareToken}
-          onUpdate={() => setUpdatedAt(Date.now())}
+          onUpdate={(): void => setUpdatedAt(Date.now())}
         />
         <div className={styles.poolContent}>
           {sorobanContext.activeChain &&
@@ -145,7 +148,7 @@ const Home = (): JSX.Element => {
                 shareToken={shareToken}
                 reserves={reserves}
                 totalShares={totalShares}
-                onUpdate={() => setUpdatedAt(Date.now())}
+                onUpdate={(): void => setUpdatedAt(Date.now())}
               />
             ) : (
               <div className={styles.card}>

--- a/liquidity-pool/frontend/src/components/atoms/mint-button/index.tsx
+++ b/liquidity-pool/frontend/src/components/atoms/mint-button/index.tsx
@@ -4,6 +4,7 @@ import styles from './styles.module.scss'
 
 import { LoadingButton } from '@mui/lab';
 import { IMintFunction } from 'interfaces/soroban/token';
+import { Address } from '../../../contracts';
 
 
 interface IMintButton {
@@ -19,9 +20,9 @@ const MintButton: FunctionComponent<IMintButton> = ({ account, decimals, mint, o
 
   return (
     <LoadingButton
-      onClick={async () => {
+      onClick={async (): Promise<void> => {
         setSubmitting(true)
-        await mint({ to: account, amount: amount }, { signAndSend: true })
+        await mint({ to: new Address(account), amount })
         setSubmitting(false)
         onUpdate()
       }}

--- a/liquidity-pool/frontend/src/components/molecules/deposit/index.tsx
+++ b/liquidity-pool/frontend/src/components/molecules/deposit/index.tsx
@@ -7,7 +7,7 @@ import { IToken } from "interfaces/soroban/token"
 import { InputCurrency, InputPercentage } from "components/atoms"
 import { TokenAIcon, TokenBIcon } from 'components/icons';
 import { ErrorText } from 'components/atoms/error-text';
-import { deposit } from 'liquidity-pool-contract'
+import { Address, liquidityPoolContract } from '../../../contracts'
 
 
 interface IFormValues {
@@ -48,8 +48,8 @@ const Deposit: FunctionComponent<IDeposit> = ({ account, tokenA, tokenB, onUpdat
             const minA = (parseFloat(tokenAAmount) - parseFloat(maxSlippage) * parseFloat(tokenAAmount) / 100);
             const minB = (parseFloat(tokenBAmount) - parseFloat(maxSlippage) * parseFloat(tokenBAmount) / 100);
 
-            await deposit({
-                to: account,
+            await liquidityPoolContract.deposit({
+                to: new Address(account),
                 desired_a: BigInt(parseFloat(tokenAAmount) * 10 ** tokenA.decimals),
                 desired_b: BigInt(parseFloat(tokenBAmount) * 10 ** tokenB.decimals),
                 min_a: BigInt(minA * 10 ** tokenA.decimals),

--- a/liquidity-pool/frontend/src/components/molecules/swap/index.tsx
+++ b/liquidity-pool/frontend/src/components/molecules/swap/index.tsx
@@ -9,7 +9,7 @@ import { IReserves } from "interfaces/soroban/liquidityPool"
 import { Icon, IconNames, InputCurrency, InputPercentage, Tooltip } from "components/atoms"
 import { SwapIcon, TokenAIcon, TokenBIcon } from 'components/icons';
 import { ErrorText } from 'components/atoms/error-text';
-import { swap } from 'liquidity-pool-contract'
+import { Address, liquidityPoolContract } from '../../../contracts'
 
 interface IFormValues {
     buyAmount: string;
@@ -66,8 +66,8 @@ const Swap: FunctionComponent<ISwap> = ({ account, tokenA, tokenB, reserves, onU
         setError(false)
 
         try {
-            await swap({
-                to: account,
+            await liquidityPoolContract.swap({
+                to: new Address(account),
                 buy_a: swapTokens.buy.token == tokenA,
                 out: BigInt(parseFloat(formValues.buyAmount) * 10 ** swapTokens.buy.token.decimals),
                 in_max: BigInt(maxSold * 10 ** swapTokens.sell.token.decimals),

--- a/liquidity-pool/frontend/src/components/molecules/withdraw/index.tsx
+++ b/liquidity-pool/frontend/src/components/molecules/withdraw/index.tsx
@@ -8,7 +8,7 @@ import { IReserves } from "interfaces/soroban/liquidityPool"
 import { Icon, IconNames, InputPercentage, InputSlider, Tooltip } from "components/atoms"
 import { Utils } from 'shared/utils';
 import { ErrorText } from 'components/atoms/error-text';
-import { withdraw } from 'liquidity-pool-contract'
+import { Address, liquidityPoolContract } from '../../../contracts'
 
 
 interface IFormValues {
@@ -59,8 +59,8 @@ const Withdraw: FunctionComponent<IWithdraw> = ({ account, tokenA, tokenB, share
         setSubmitting(true)
         setError(false)
         try {
-            await withdraw({
-                to: account,
+            await liquidityPoolContract.withdraw({
+                to: new Address(account),
                 share_amount: shareAmount,
                 min_a: tokenATotalWithSlippage,
                 min_b: tokenBTotalWithSlippage,

--- a/liquidity-pool/frontend/src/components/organisms/account-data/index.tsx
+++ b/liquidity-pool/frontend/src/components/organisms/account-data/index.tsx
@@ -8,8 +8,7 @@ import { ConnectButton } from "components/atoms"
 import { Balance } from "components/molecules"
 import { IToken } from "interfaces/soroban/token"
 import { TokenAIcon, TokenBIcon, TokenLPIcon } from 'components/icons';
-import { mint as mintA } from 'token-a-contract'
-import { mint as mintB } from 'token-b-contract'
+import { tokenAContract, tokenBContract } from '../../../contracts'
 
 interface IAccountData {
     sorobanContext: SorobanContextType;
@@ -58,7 +57,7 @@ const BalanceData: FunctionComponent<IBalanceData> = ({ tokenA, tokenB, shareTok
                     account={account}
                     token={tokenA}
                     balance={tokenA.balance || BigInt(0)}
-                    mint={mintA}
+                    mint={tokenAContract.mint}
                     icon={TokenAIcon}
                     onUpdate={onUpdate}
                 />
@@ -66,7 +65,7 @@ const BalanceData: FunctionComponent<IBalanceData> = ({ tokenA, tokenB, shareTok
                     account={account}
                     token={tokenB}
                     balance={tokenB.balance || BigInt(0)}
-                    mint={mintB}
+                    mint={tokenBContract.mint}
                     icon={TokenBIcon}
                     onUpdate={onUpdate}
                 />

--- a/liquidity-pool/frontend/src/contracts.ts
+++ b/liquidity-pool/frontend/src/contracts.ts
@@ -1,0 +1,12 @@
+import { Contract as TokenA, networks as networksA } from 'token-a-contract'
+import { Contract as TokenB, networks as networksB } from 'token-b-contract'
+import { Contract as ShareToken, networks as networksShareToken } from 'share-token-contract'
+import { Contract as LiquidityPool, networks as networksLiquidityPool } from 'liquidity-pool-contract'
+
+const rpcUrl = 'https://rpc-futurenet.stellar.org	'
+
+export { Address } from 'token-a-contract'
+export const tokenAContract = new TokenA({ ...networksA.futurenet, rpcUrl })
+export const tokenBContract = new TokenB({ ...networksB.futurenet, rpcUrl })
+export const shareTokenContract = new ShareToken({ ...networksShareToken.futurenet, rpcUrl })
+export const liquidityPoolContract = new LiquidityPool({ ...networksLiquidityPool.futurenet, rpcUrl })

--- a/liquidity-pool/frontend/src/interfaces/soroban/token.ts
+++ b/liquidity-pool/frontend/src/interfaces/soroban/token.ts
@@ -1,3 +1,5 @@
+import { Address } from '../../contracts'
+
 interface IToken {
     symbol: string;
     decimals: number;
@@ -5,12 +7,11 @@ interface IToken {
 }
 
 interface IMintParams {
-    to: string;
+    to: Address;
     amount: bigint;
 }
 
 interface IMintOptions {
-    signAndSend?: boolean;
     fee?: number;
 }
 

--- a/liquidity-pool/initialize.sh
+++ b/liquidity-pool/initialize.sh
@@ -11,6 +11,19 @@ LIQUIDITY_POOL_WASM=$WASM_PATH"soroban_liquidity_pool_contract.optimized.wasm"
 ABUNDANCE_WASM=$WASM_PATH"abundance_token.optimized.wasm"
 TOKEN_WASM="contracts/liquidity-pool/token/soroban_token_contract.wasm"
 
+PATH=./target/bin:$PATH
+
+if [[ -d "./.soroban/contracts" ]]; then
+  echo "Found existing './.soroban/contracts' directory; already initialized."
+  exit 0
+fi
+
+if [[ -f "./target/bin/soroban" ]]; then
+  echo "Using soroban binary from ./target/bin"
+else
+  echo "Building pinned soroban binary"
+  cargo install_soroban
+fi
 
 if [[ "$SOROBAN_RPC_HOST" == "" ]]; then
   # If soroban-cli is called inside the soroban-preview docker container,
@@ -162,10 +175,10 @@ echo "Share ID: $SHARE_ID"
 
 
 echo "Generating bindings"
-soroban contract bindings typescript --wasm $ABUNDANCE_WASM --network $NETWORK --contract-id $ABUNDANCE_A_ID --contract-name token-a --output-dir ".soroban/contracts/token-a"
-soroban contract bindings typescript --wasm $ABUNDANCE_WASM  --network $NETWORK --contract-id $ABUNDANCE_B_ID --contract-name token-b --output-dir ".soroban/contracts/token-b"
-soroban contract bindings typescript --wasm contracts/liquidity-pool/token/soroban_token_contract.wasm --network $NETWORK --contract-id $SHARE_ID --contract-name share-token --output-dir ".soroban/contracts/share-token"
-soroban contract bindings typescript --wasm $LIQUIDITY_POOL_WASM --network $NETWORK --contract-id $LIQUIDITY_POOL_ID --contract-name liquidity-pool --output-dir ".soroban/contracts/liquidity-pool"
+soroban contract bindings typescript --network $NETWORK --contract-id $ABUNDANCE_A_ID --output-dir ".soroban/contracts/token-a" --overwrite
+soroban contract bindings typescript --network $NETWORK --contract-id $ABUNDANCE_B_ID --output-dir ".soroban/contracts/token-b" --overwrite
+soroban contract bindings typescript --network $NETWORK --contract-id $SHARE_ID --output-dir ".soroban/contracts/share-token" --overwrite
+soroban contract bindings typescript --network $NETWORK --contract-id $LIQUIDITY_POOL_ID --output-dir ".soroban/contracts/liquidity-pool" --overwrite
 
 echo "Done"
 


### PR DESCRIPTION
This updates Liquidity Pool with a `cargo install_soroban` alias that pins the version of soroban-cli from https://github.com/AhaLabs/soroban-tools/pull/12

This version builds off of the latest `AhaLabs#smartdeploy` fork, which doesn't have everything on the `stellar#main` fork but _does_ work with Futurenet. It also adds a fix that this app needed to continue working the same way.

I've also added some logic to `initialize.sh` to skip initialization if the `.soroban/contracts` directory already exists, and to run `install_soroban` if `target/bin/soroban` isn't found. **Note:** if the version of soroban-cli specified in `.cargo/config.toml` changes, you will need to manually `rm target/bin/soroban` and re-run `initialize.sh`.

Finally, the new generated libraries export a `Contract` class instead of a bag of functions. This adds a new `frontend/src/contracts.ts` that exports instantiated versions of all the contracts needed by the frontend, then updates all the imports and calls throughout.